### PR TITLE
De-pivotal code and make a code.cloudfoundry.org package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ to build valid PKIs for test.
 
 ## usage
 
+**Note**: This repository should be imported as `code.cloudfoundry.org/tlsconfig`
+
 See [GoDoc][godoc].
 
-[godoc]: https://godoc.org/github.com/pivotal-cf/tlsconfig
+[godoc]: https://godoc.org/code.cloudfoundry.org/tlsconfig
 
 ## getting help
 

--- a/certtest/package.go
+++ b/certtest/package.go
@@ -1,0 +1,1 @@
+package certtest // import "code.cloudfoundry.org/tlsconfig/certtest"

--- a/config.go
+++ b/config.go
@@ -1,12 +1,11 @@
 // Package tlsconfig provides opintionated helpers for building tls.Configs.
-// It keeps up to date with internal Pivotal best practices and external
+// It keeps up to date with internal CloudFoundry best practices and external
 // industry best practices.
 package tlsconfig
 
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"log"
 )
 
 // Config represents a half configured TLS configuration. It can be made usable
@@ -100,16 +99,6 @@ func WithInternalServiceDefaults() TLSOption {
 			tls.CurveP256,
 		}
 	}
-}
-
-// WithPivotalDefaults is the same as WithInternalServiceDefaults and is only
-// provided for backwards compatibility. These configuration options are now
-// used beyond just Pivotal.
-//
-// Deprecated: Use WithInternalServiceDefaults() instead.
-func WithPivotalDefaults() TLSOption {
-	log.Println("DEPRECATED! tlsconfig: Please use WithInternalServiceDefaults() rather than WithPivotalDefaults()")
-	return WithInternalServiceDefaults()
 }
 
 // WithIdentity sets the identity of the server or client which will be

--- a/config_test.go
+++ b/config_test.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/pivotal-cf/tlsconfig"
-	"github.com/pivotal-cf/tlsconfig/certtest"
+	"code.cloudfoundry.org/tlsconfig"
+	"code.cloudfoundry.org/tlsconfig/certtest"
 )
 
 func TestE2E(t *testing.T) {
@@ -93,14 +93,6 @@ func TestInternalDefaults(t *testing.T) {
 		name   string
 		config *tls.Config
 	}{
-		{
-			name:   "pivotal (client)",
-			config: tlsconfig.Build(tlsconfig.WithPivotalDefaults()).Client(),
-		},
-		{
-			name:   "pivotal (server)",
-			config: tlsconfig.Build(tlsconfig.WithPivotalDefaults()).Server(),
-		},
 		{
 			name:   "internal (client)",
 			config: tlsconfig.Build(tlsconfig.WithInternalServiceDefaults()).Client(),

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/pivotal-cf/tlsconfig
+module code.cloudfoundry.org/tlsconfig
 
 require github.com/square/certstrap v1.1.1

--- a/package.go
+++ b/package.go
@@ -1,0 +1,1 @@
+package tlsconfig // import "code.cloudfoundry.org/tlsconfig"


### PR DESCRIPTION
This change removes more references to Pivotal and makes the package import path `code.cloudfoundry.org/tlsconfig` in line with other `cloudfoundry` org Go packages.

We left in this reference: https://github.com/cloudfoundry/tlsconfig/blob/a69ae9ffab8df04fb51451427b6b5203990c2fe0/config.go#L77 as we were not yet sure what to update this to or if we should just leave it alone, comments on this would be appreciated