### PR TITLE
Add support for loading keypair/CA from files

### DIFF
--- a/certtest/certtest.go
+++ b/certtest/certtest.go
@@ -148,6 +148,21 @@ func (c *Certificate) TLSCertificate() (tls.Certificate, error) {
 	return tls.X509KeyPair(certBytes, keyBytes)
 }
 
+// CertificatePEMAndPrivateKey returns the certificate as a PEM encoded bytes and the private key bytes.
+func (c *Certificate) CertificatePEMAndPrivateKey() ([]byte, []byte, error) {
+	certBytes, err := c.cert.Export()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyBytes, err := c.key.ExportPrivate()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return certBytes, keyBytes, nil
+}
+
 type signOptions struct {
 	domains []string
 	ips     []net.IP

--- a/config.go
+++ b/config.go
@@ -150,12 +150,12 @@ func WithClientAuthenticationFromFile(caPath string) ServerOption {
 	return func(c *tls.Config) error {
 		caBytes, err := ioutil.ReadFile(caPath)
 		if err != nil {
-			return fmt.Errorf("failed read ca cert file: %s", err.Error())
+			return fmt.Errorf("failed to read file %s: %s", caPath, err.Error())
 		}
 
 		caCertPool := x509.NewCertPool()
 		if ok := caCertPool.AppendCertsFromPEM(caBytes); !ok {
-			return fmt.Errorf("Unable to load caCert")
+			return fmt.Errorf("unable to load CA certificate at %s", caPath)
 		}
 
 		c.ClientAuth = tls.RequireAndVerifyClientCert
@@ -179,12 +179,12 @@ func WithAuthorityFromFile(caPath string) ClientOption {
 	return func(c *tls.Config) error {
 		caBytes, err := ioutil.ReadFile(caPath)
 		if err != nil {
-			return fmt.Errorf("failed read ca cert file: %s", err.Error())
+			return fmt.Errorf("failed to read file %s: %s", caPath, err.Error())
 		}
 
 		caCertPool := x509.NewCertPool()
 		if ok := caCertPool.AppendCertsFromPEM(caBytes); !ok {
-			return fmt.Errorf("Unable to load caCert")
+			return fmt.Errorf("unable to load CA certificate at %s", caPath)
 		}
 
 		c.RootCAs = caCertPool

--- a/config_test.go
+++ b/config_test.go
@@ -8,7 +8,9 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"code.cloudfoundry.org/tlsconfig"
@@ -48,18 +50,74 @@ func TestE2E(t *testing.T) {
 
 	// Typically we would share a base configuration but here we're pretending
 	// to be two different services.
-	serverConf := tlsconfig.Build(
+	serverConf, err := tlsconfig.Build(
 		tlsconfig.WithIdentity(serverTLSCrt),
 	).Server(
 		tlsconfig.WithClientAuthentication(pool),
 	)
+	if err != nil {
+		t.Fatalf("failed to build server config: %v", err)
+	}
 
-	clientConf := tlsconfig.Build(
+	clientConf, err := tlsconfig.Build(
 		tlsconfig.WithIdentity(clientTLSCrt),
 	).Client(
 		tlsconfig.WithAuthority(pool),
 	)
+	if err != nil {
+		t.Fatalf("failed to build client config: %v", err)
+	}
 
+	testClientServerTLSConnection(t, clientConf, serverConf)
+}
+
+func TestE2EFromFile(t *testing.T) {
+	t.Parallel()
+
+	ca, err := certtest.BuildCA("tlsconfig")
+	if err != nil {
+		t.Fatalf("failed to build CA: %v", err)
+	}
+	caFile, err := writeCAToTempFile(ca)
+	if err != nil {
+		t.Fatalf("failed to write CA file: %v", err)
+	}
+	defer os.Remove(caFile)
+
+	serverCertFile, serverKeyFile, err := generateKeypairToTempFilesFromCA(ca)
+	if err != nil {
+		t.Fatalf("failed to generate server keypair: %v", err)
+	}
+
+	clientCertFile, clientKeyFile, err := generateKeypairToTempFilesFromCA(ca)
+	if err != nil {
+		t.Fatalf("failed to generate server keypair: %v", err)
+	}
+
+	// Typically we would share a base configuration but here we're pretending
+	// to be two different services.
+	serverConf, err := tlsconfig.Build(
+		tlsconfig.WithIdentityFromFile(serverCertFile, serverKeyFile),
+	).Server(
+		tlsconfig.WithClientAuthenticationFromFile(caFile),
+	)
+	if err != nil {
+		t.Fatalf("failed to build server config: %v", err)
+	}
+
+	clientConf, err := tlsconfig.Build(
+		tlsconfig.WithIdentityFromFile(clientCertFile, clientKeyFile),
+	).Client(
+		tlsconfig.WithAuthorityFromFile(caFile),
+	)
+	if err != nil {
+		t.Fatalf("failed to build client config: %v", err)
+	}
+
+	testClientServerTLSConnection(t, clientConf, serverConf)
+}
+
+func testClientServerTLSConnection(t *testing.T, clientConf, serverConf *tls.Config) {
 	s := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "hello, world!")
 	}))
@@ -85,9 +143,218 @@ func TestE2E(t *testing.T) {
 	}
 }
 
+type buildResult struct {
+	name string
+	err  error
+}
+
+func TestLoadKeypairFails(t *testing.T) {
+	t.Parallel()
+
+	certFile, keyFile, caFile, err := generateKeypairAndCAToTempFiles()
+	if err != nil {
+		t.Fatalf("failed generating keypair and ca files: %v", err)
+	}
+	fmt.Println(certFile, keyFile, caFile)
+	defer func() {
+		os.Remove(certFile)
+		os.Remove(keyFile)
+		os.Remove(caFile)
+	}()
+
+	// generate file invalid for use as cert or key
+	invalidFile, err := ioutil.TempFile("", "invalid")
+	if err != nil {
+		t.Fatalf("failed to create temp invalid-key: %v", err)
+	}
+	defer invalidFile.Close()
+
+	if err := ioutil.WriteFile(invalidFile.Name(), []byte("invalid"), 0666); err != nil {
+		t.Fatalf("failed to write invalid file: %v", err)
+	}
+	defer os.Remove(invalidFile.Name())
+
+	keypairs := []struct {
+		name     string
+		certFile string
+		keyFile  string
+	}{
+		{name: "cert file missing", certFile: "does not exist", keyFile: keyFile},
+		{name: "cert file invalid", certFile: invalidFile.Name(), keyFile: keyFile},
+		{name: "key file missing", certFile: certFile, keyFile: "does not exist"},
+		{name: "key file invalid", certFile: certFile, keyFile: invalidFile.Name()},
+	}
+
+	var buildResults []buildResult
+	for _, keypair := range keypairs {
+		_, err := tlsconfig.Build(tlsconfig.WithIdentityFromFile(keypair.certFile, keypair.keyFile)).Client()
+		buildResults = append(buildResults, buildResult{keypair.name + " (client)", err})
+		_, err = tlsconfig.Build(tlsconfig.WithIdentityFromFile(keypair.certFile, keypair.keyFile)).Server()
+		buildResults = append(buildResults, buildResult{keypair.name + " (server)", err})
+	}
+
+	for _, br := range buildResults {
+		br := br // capture variable
+		t.Run(br.name, func(t *testing.T) {
+			t.Parallel()
+
+			if br.err == nil {
+				t.Fatal("building config should have errored")
+			}
+			if !strings.HasPrefix(br.err.Error(), "failed to load keypair") {
+				t.Fatalf("unexpected error prefix returned; have: %v, want: 'failed to load keypair'", br.err)
+			}
+		})
+	}
+}
+
+func TestLoadCAFails(t *testing.T) {
+	t.Parallel()
+
+	_, clientCAErr := tlsconfig.Build().Client(tlsconfig.WithAuthorityFromFile("does not exist"))
+	_, serverCAErr := tlsconfig.Build().Server(tlsconfig.WithClientAuthenticationFromFile("does not exist"))
+
+	buildResults := []buildResult{
+		{name: "CA cert file missing (client)", err: clientCAErr},
+		{name: "CA cert file missing (server)", err: serverCAErr},
+	}
+
+	for _, br := range buildResults {
+		br := br // capture variable
+		t.Run(br.name, func(t *testing.T) {
+			t.Parallel()
+
+			if br.err == nil {
+				t.Fatal("building config should have errored")
+			}
+			if !strings.HasPrefix(br.err.Error(), "failed read ca cert file") {
+				t.Fatalf("unexpected error prefix returned; have: %v, want: 'failed read ca cert file", br.err)
+			}
+		})
+	}
+}
+
+func generateKeypairAndCAToTempFiles() (string, string, string, error) {
+	ca, err := certtest.BuildCA("tlsconfig")
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to build CA: %s", err)
+	}
+
+	caFile, err := writeCAToTempFile(ca)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	certFile, keyFile, err := generateKeypairToTempFilesFromCA(ca)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return certFile, keyFile, caFile, nil
+}
+
+func writeCAToTempFile(ca *certtest.Authority) (string, error) {
+	caBytes, err := ca.CertificatePEM()
+	if err != nil {
+		return "", fmt.Errorf("failed to get CA PEM encoding: %s", err)
+	}
+
+	caFile, err := ioutil.TempFile("", "CA")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp CA file: %s", err)
+	}
+	defer caFile.Close()
+
+	if err := ioutil.WriteFile(caFile.Name(), caBytes, 0666); err != nil {
+		return "", fmt.Errorf("failed to write CA file: %s", err)
+	}
+
+	return caFile.Name(), nil
+}
+
+func generateKeypairToTempFilesFromCA(ca *certtest.Authority) (string, string, error) {
+	cert, err := ca.BuildSignedCertificate("cert")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to make certificate keypair: %s", err)
+	}
+
+	certBytes, keyBytes, err := cert.CertificatePEMAndPrivateKey()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get cert and key bytes: %s", err)
+	}
+
+	keyFile, err := ioutil.TempFile("", "key")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temp key file: %s", err)
+	}
+	defer keyFile.Close()
+
+	if err := ioutil.WriteFile(keyFile.Name(), keyBytes, 0666); err != nil {
+		return "", "", fmt.Errorf("failed to write key file: %s", err)
+	}
+
+	certFile, err := ioutil.TempFile("", "cert")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temp cert file: %s", err)
+	}
+	defer certFile.Close()
+
+	if err := ioutil.WriteFile(certFile.Name(), certBytes, 0666); err != nil {
+		return "", "", fmt.Errorf("failed to write cert file: %s", err)
+	}
+
+	return certFile.Name(), keyFile.Name(), nil
+}
+
+func TestCAInvalidFails(t *testing.T) {
+	t.Parallel()
+
+	invalidCAFile, err := ioutil.TempFile("", "invalid-CA")
+	if err != nil {
+		t.Fatalf("failed to create temp invalid-CA: %v", err)
+	}
+	defer invalidCAFile.Close()
+
+	if err := ioutil.WriteFile(invalidCAFile.Name(), []byte("invalid"), 0666); err != nil {
+		t.Fatalf("failed to write invalid-CA file: %v", err)
+	}
+	defer os.Remove(invalidCAFile.Name())
+
+	_, clientCAErr := tlsconfig.Build().Client(tlsconfig.WithAuthorityFromFile(invalidCAFile.Name()))
+	_, serverCAErr := tlsconfig.Build().Server(tlsconfig.WithClientAuthenticationFromFile(invalidCAFile.Name()))
+
+	buildResults := []buildResult{
+		{name: "CA cert file invalid (client)", err: clientCAErr},
+		{name: "CA cert file invalid (server)", err: serverCAErr},
+	}
+
+	for _, br := range buildResults {
+		br := br // capture variable
+		t.Run(br.name, func(t *testing.T) {
+			t.Parallel()
+
+			if br.err == nil {
+				t.Fatal("building config should have errored")
+			}
+			if !strings.HasPrefix(br.err.Error(), "Unable to load caCert") {
+				t.Fatalf("unexpected error prefix returned; have: %v, want: 'Unable to load caCert", br.err)
+			}
+		})
+	}
+}
+
 func TestInternalDefaults(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	t.Parallel()
+
+	clientConfig, err := tlsconfig.Build(tlsconfig.WithInternalServiceDefaults()).Client()
+	if err != nil {
+		t.Fatalf("failed to build client config: %v", err)
+	}
+	serverConfig, err := tlsconfig.Build(tlsconfig.WithInternalServiceDefaults()).Server()
+	if err != nil {
+		t.Fatalf("failed to build server config: %v", err)
+	}
 
 	var tcs = []struct {
 		name   string
@@ -95,11 +362,11 @@ func TestInternalDefaults(t *testing.T) {
 	}{
 		{
 			name:   "internal (client)",
-			config: tlsconfig.Build(tlsconfig.WithInternalServiceDefaults()).Client(),
+			config: clientConfig,
 		},
 		{
 			name:   "internal (server)",
-			config: tlsconfig.Build(tlsconfig.WithInternalServiceDefaults()).Server(),
+			config: serverConfig,
 		},
 	}
 


### PR DESCRIPTION
This change adds options to load a keypair or CA for a client/server from files

This is a common pattern of usage in Diego and other components and we hope adding this removes some burden from potential users of this library and removes commonly duplicated code