### PR TITLE
build name to cert map after setting certificates

### DIFF
--- a/config.go
+++ b/config.go
@@ -109,7 +109,6 @@ func WithIdentity(cert tls.Certificate) TLSOption {
 		fail := func(err error) error {
 			return fmt.Errorf("failed to load keypair: %s", err.Error())
 		}
-		c.Certificates = []tls.Certificate{cert}
 		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
 		if err != nil {
 			return fail(err)
@@ -118,6 +117,8 @@ func WithIdentity(cert tls.Certificate) TLSOption {
 		if err != nil {
 			return fail(err)
 		}
+		c.Certificates = []tls.Certificate{cert}
+		c.BuildNameToCertificate()
 		return nil
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -67,6 +67,10 @@ func TestE2E(t *testing.T) {
 		t.Fatalf("failed to build server config: %v", err)
 	}
 
+	if serverConf.NameToCertificate == nil {
+		t.Error("tls.Config.NameToCertificate should not be nil")
+	}
+
 	clientConf, err := tlsconfig.Build(
 		tlsconfig.WithIdentity(clientTLSCrt),
 	).Client(
@@ -74,6 +78,10 @@ func TestE2E(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("failed to build client config: %v", err)
+	}
+
+	if clientConf.NameToCertificate == nil {
+		t.Error("tls.Config.NameToCertificate should not be nil")
 	}
 
 	testClientServerTLSConnection(t, clientConf, serverConf)


### PR DESCRIPTION
This prevents people from accidentally forgetting to run this after
setting a certificate.

Additionally, move the modification of the config below the validation.
I don't think it's possible to accidentally use this half-built and
invalid configuration due to us returning nil if an error occurs during
building. However, having invalid data being used at all still sat wrong
with me.

Closes #8