### PR TITLE
use %w directive to wrap errors in fmt.Errorf

### DIFF
--- a/config.go
+++ b/config.go
@@ -107,7 +107,7 @@ func WithInternalServiceDefaults() TLSOption {
 func WithIdentity(cert tls.Certificate) TLSOption {
 	return func(c *tls.Config) error {
 		fail := func(err error) error {
-			return fmt.Errorf("failed to load keypair: %s", err.Error())
+			return fmt.Errorf("failed to load keypair: %w", err)
 		}
 		c.Certificates = []tls.Certificate{cert}
 		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
@@ -128,7 +128,7 @@ func WithIdentityFromFile(certPath string, keyPath string) TLSOption {
 	return func(c *tls.Config) error {
 		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {
-			return fmt.Errorf("failed to load keypair: %s", err.Error())
+			return fmt.Errorf("failed to load keypair: %w", err)
 		}
 		return WithIdentity(cert)(c)
 	}
@@ -150,7 +150,7 @@ func WithClientAuthenticationFromFile(caPath string) ServerOption {
 	return func(c *tls.Config) error {
 		caBytes, err := ioutil.ReadFile(caPath)
 		if err != nil {
-			return fmt.Errorf("failed to read file %s: %s", caPath, err.Error())
+			return fmt.Errorf("failed to read file %s: %w", caPath, err)
 		}
 
 		caCertPool := x509.NewCertPool()
@@ -177,7 +177,7 @@ func WithAuthorityFromFile(caPath string) ClientOption {
 	return func(c *tls.Config) error {
 		caBytes, err := ioutil.ReadFile(caPath)
 		if err != nil {
-			return fmt.Errorf("failed to read file %s: %s", caPath, err.Error())
+			return fmt.Errorf("failed to read file %s: %w", caPath, err)
 		}
 
 		caCertPool := x509.NewCertPool()

--- a/config_test.go
+++ b/config_test.go
@@ -454,17 +454,17 @@ func testClientServerTLSConnection(t *testing.T, clientConf, serverConf *tls.Con
 func writeCAToTempFile(tempDir string, ca *certtest.Authority) (string, error) {
 	caBytes, err := ca.CertificatePEM()
 	if err != nil {
-		return "", fmt.Errorf("failed to get CA PEM encoding: %s", err)
+		return "", fmt.Errorf("failed to get CA PEM encoding: %w", err)
 	}
 
 	caFile, err := ioutil.TempFile(tempDir, "CA")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp CA file: %s", err)
+		return "", fmt.Errorf("failed to create temp CA file: %w", err)
 	}
 	defer caFile.Close()
 
 	if err := ioutil.WriteFile(caFile.Name(), caBytes, 0666); err != nil {
-		return "", fmt.Errorf("failed to write CA file: %s", err)
+		return "", fmt.Errorf("failed to write CA file: %w", err)
 	}
 
 	return caFile.Name(), nil
@@ -481,32 +481,32 @@ func generateKeypairToTempFilesFromCA(tempDir string, ca *certtest.Authority, ex
 		cert, err = ca.BuildSignedCertificate("cert")
 	}
 	if err != nil {
-		return "", "", fmt.Errorf("failed to make certificate keypair: %s", err)
+		return "", "", fmt.Errorf("failed to make certificate keypair: %w", err)
 	}
 
 	certBytes, keyBytes, err := cert.CertificatePEMAndPrivateKey()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get cert and key bytes: %s", err)
+		return "", "", fmt.Errorf("failed to get cert and key bytes: %w", err)
 	}
 
 	keyFile, err := ioutil.TempFile(tempDir, "key")
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create temp key file: %s", err)
+		return "", "", fmt.Errorf("failed to create temp key file: %w", err)
 	}
 	defer keyFile.Close()
 
 	if err := ioutil.WriteFile(keyFile.Name(), keyBytes, 0666); err != nil {
-		return "", "", fmt.Errorf("failed to write key file: %s", err)
+		return "", "", fmt.Errorf("failed to write key file: %w", err)
 	}
 
 	certFile, err := ioutil.TempFile(tempDir, "cert")
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create temp cert file: %s", err)
+		return "", "", fmt.Errorf("failed to create temp cert file: %w", err)
 	}
 	defer certFile.Close()
 
 	if err := ioutil.WriteFile(certFile.Name(), certBytes, 0666); err != nil {
-		return "", "", fmt.Errorf("failed to write cert file: %s", err)
+		return "", "", fmt.Errorf("failed to write cert file: %w", err)
 	}
 
 	return certFile.Name(), keyFile.Name(), nil


### PR DESCRIPTION
I don't think this will work/compile on Go versions before 1.13 so we should
make sure that most people are upgraded first.