### PR TITLE
improve error message for invalid certificate

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -323,7 +323,7 @@ func TestLoadKeypairFails(t *testing.T) {
 			name:      "cert expired",
 			certFile:  expiredCertFile,
 			keyFile:   expiredKeyFile,
-			errPrefix: "failed to load keypair: the certificate has expired or is not yet valid",
+			errPrefix: "failed to load keypair: certificate has expired",
 		},
 	}
 
@@ -354,7 +354,7 @@ func TestLoadKeypairFails(t *testing.T) {
 				t.Fatal("building config should have errored")
 			}
 			if !strings.HasPrefix(br.err.Error(), br.expectedErrPrefix) {
-				t.Fatalf("unexpected error prefix returned; have: %v, want: '%s'", br.err, br.expectedErrPrefix)
+				t.Fatalf("unexpected error prefix returned; have: %q, want: %q", br.err, br.expectedErrPrefix)
 			}
 		})
 	}

--- a/verify.go
+++ b/verify.go
@@ -2,15 +2,22 @@ package tlsconfig
 
 import (
 	"crypto/x509"
-	"errors"
+	"fmt"
 	"time"
 )
 
+const timeFormat = "2006-01-02 15:04:05 MST"
+
 func checkExpiration(cert *x509.Certificate) error {
-	sinceStart := time.Now().Sub(cert.NotBefore)
-	untilExpiry := cert.NotAfter.Sub(time.Now())
-	if untilExpiry < 0 || sinceStart < 0 {
-		return errors.New("the certificate has expired or is not yet valid")
+	now := time.Now()
+
+	if now.Before(cert.NotBefore) {
+		return fmt.Errorf("certificate is not yet valid: validity starts at %s but current time is %s", cert.NotBefore.Format(timeFormat), now.Format(timeFormat))
 	}
+
+	if now.After(cert.NotAfter) {
+		return fmt.Errorf("certificate has expired: validity ended at %s but current time is %s", cert.NotAfter.Format(timeFormat), now.Format(timeFormat))
+	}
+
 	return nil
 }


### PR DESCRIPTION
The new message shows the expiry mismatch in more detail and includes
the current time and the time of expiry/validity.