### PR TITLE
add certificate pool building helpers

### DIFF
--- a/authority.go
+++ b/authority.go
@@ -1,0 +1,113 @@
+package tlsconfig
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+)
+
+// PoolOption is an functional option type that can be used to configure a
+// certificate pool.
+type PoolOption func(*x509.CertPool) error
+
+// PoolBuilder is used to build a certificate pool. You normally won't need to
+// Build this yourself and instead should use the WithAuthorityBuilder and
+// WithClientAuthenticationBuilder functions.
+type PoolBuilder struct {
+	base *x509.CertPool
+	opts []PoolOption
+	err  error
+}
+
+// Build creates the certificate pool.
+func (pb PoolBuilder) Build() (*x509.CertPool, error) {
+	if pb.err != nil {
+		return nil, pb.err
+	}
+
+	for _, opt := range pb.opts {
+		if err := opt(pb.base); err != nil {
+			return nil, err
+		}
+	}
+
+	return pb.base, nil
+}
+
+// FromEmptyPool creates a PoolBuilder from an empty certificate pool. The
+// options passed can amend the returned pool.
+func FromEmptyPool(opts ...PoolOption) PoolBuilder {
+	return PoolBuilder{
+		base: x509.NewCertPool(),
+		opts: opts,
+	}
+}
+
+// FromSystemPool creates a PoolBuilder from the system's certificate pool. The
+// options passed can amend the returned pool.
+func FromSystemPool(opts ...PoolOption) PoolBuilder {
+	pool, err := x509.SystemCertPool()
+	return PoolBuilder{
+		base: pool,
+		err:  err,
+		opts: opts,
+	}
+}
+
+// WithCertsFromFile will add all of the certificates found in a PEM-encoded
+// file to a certificate pool.
+func WithCertsFromFile(path string) PoolOption {
+	return func(pool *x509.CertPool) error {
+		pemCerts, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read certificate(s) at path %q: %s", path, err)
+		}
+
+		certsRead := 0
+		for len(pemCerts) > 0 {
+			var block *pem.Block
+			block, pemCerts = pem.Decode(pemCerts)
+			if block == nil {
+				break
+			}
+			if len(block.Headers) != 0 {
+				return fmt.Errorf("unexpected headers in PEM block in file %q: %v", path, block.Headers)
+			}
+			if block.Type != "CERTIFICATE" {
+				return fmt.Errorf("unexpected PEM block type %q in file %q", block.Type, path)
+			}
+
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return fmt.Errorf("failed to parse certificate in %q: %s", path, err)
+			}
+
+			if err := WithCert(cert)(pool); err != nil {
+				return fmt.Errorf("failed to add certificate in file %q to pool: %s", path, err)
+			}
+
+			certsRead++
+		}
+
+		if certsRead == 0 {
+			return fmt.Errorf("no valid certificates read from file %q", path)
+		}
+
+		return nil
+	}
+}
+
+// WithCert will add the certificate directly to a certificate pool.
+func WithCert(cert *x509.Certificate) PoolOption {
+	return func(pool *x509.CertPool) error {
+		// We do not check if the certificate is valid here in case that a user
+		// has an expired root certificate that they never use in their system
+		// certificate store.
+		//
+		// Perhaps we can only check the expiration in the case the that
+		// certificate is user specified?
+		pool.AddCert(cert)
+		return nil
+	}
+}

--- a/authority_test.go
+++ b/authority_test.go
@@ -1,0 +1,130 @@
+package tlsconfig
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"code.cloudfoundry.org/tlsconfig/certtest"
+)
+
+func TestEmptyPool(t *testing.T) {
+	t.Parallel()
+	pool, err := FromEmptyPool().Build()
+	if err != nil {
+		t.Fatalf("unexpected error when building empty pool: %q", err)
+	}
+
+	if size := len(pool.Subjects()); size != 0 {
+		t.Errorf("expected pool to be empty but it had %d certificates", size)
+	}
+}
+
+func TestSystemPool(t *testing.T) {
+	t.Parallel()
+	pool, err := FromSystemPool().Build()
+	if err != nil {
+		t.Fatalf("unexpected error when building system pool: %q", err)
+	}
+
+	if size := len(pool.Subjects()); size == 0 {
+		t.Error("expected pool to contain something but it did not")
+	}
+}
+
+func TestWithCert(t *testing.T) {
+	t.Parallel()
+
+	auth, err := certtest.BuildCA("theauthority")
+	if err != nil {
+		t.Fatalf("failed to create CA: %s", err)
+	}
+
+	cert, err := auth.Certificate()
+	if err != nil {
+		t.Fatalf("failed to create certificate: %s", err)
+	}
+
+	pool, err := FromEmptyPool(
+		WithCert(cert),
+	).Build()
+	if err != nil {
+		t.Fatalf("unexpected error when building pool: %q", err)
+	}
+
+	if want, have := 1, len(pool.Subjects()); have != want {
+		t.Errorf("expected pool to have size %d but it had %d certificates", want, have)
+	}
+
+	if s, subj := "theauthority", string(pool.Subjects()[0]); !strings.Contains(subj, s) {
+		t.Errorf("pool should have contained cert with subject %q but it was acutally %q", s, subj)
+	}
+}
+
+func TestLoadCertsFromFile(t *testing.T) {
+	t.Parallel()
+
+	auth, err := certtest.BuildCA("authority")
+	if err != nil {
+		t.Fatalf("failed to create CA: %s", err)
+	}
+
+	cert1, err := auth.BuildSignedCertificate("cert1")
+	if err != nil {
+		t.Fatalf("failed to create certificate: %s", err)
+	}
+
+	cert1Pem, _, err := cert1.CertificatePEMAndPrivateKey()
+	if err != nil {
+		t.Fatalf("failed to PEM-encode certificate: %s", err)
+	}
+
+	cert2, err := auth.BuildSignedCertificate("cert2")
+	if err != nil {
+		t.Fatalf("failed to create certificate: %s", err)
+	}
+
+	cert2Pem, _, err := cert2.CertificatePEMAndPrivateKey()
+	if err != nil {
+		t.Fatalf("failed to PEM-encode certificate: %s", err)
+	}
+
+	f, err := ioutil.TempFile("", "tlsconfig_authority")
+	if err != nil {
+		t.Fatalf("failed to create temporary certificate file: %s", err)
+	}
+
+	if _, err := f.Write(cert1Pem); err != nil {
+		t.Fatalf("failed to write PEM to file: %s", err)
+	}
+
+	if _, err := f.Write(cert2Pem); err != nil {
+		t.Fatalf("failed to write PEM to file: %s", err)
+	}
+
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close certificate file: %s", err)
+	}
+	defer os.Remove(f.Name())
+
+	pool, err := FromEmptyPool(
+		WithCertsFromFile(f.Name()),
+	).Build()
+	if err != nil {
+		t.Fatalf("unexpected error when building pool: %q", err)
+	}
+
+	// We add 2 certificates to the pool from the file.
+	if want, have := 2, len(pool.Subjects()); have != want {
+		t.Errorf("expected pool to have size %d but it had %d certificates", want, have)
+	}
+
+	if s, subj := "cert1", string(pool.Subjects()[0]); !strings.Contains(subj, s) {
+		t.Errorf("pool should have contained cert with subject %q but it was acutally %q", s, subj)
+	}
+
+	if s, subj := "cert2", string(pool.Subjects()[1]); !strings.Contains(subj, s) {
+		t.Errorf("pool should have contained cert with subject %q but it was acutally %q", s, subj)
+	}
+}

--- a/certtest/certtest.go
+++ b/certtest/certtest.go
@@ -143,6 +143,11 @@ func (a *Authority) CertificatePEM() ([]byte, error) {
 	return a.cert.Export()
 }
 
+// Certificate resunts the authority's certificate.
+func (a *Authority) Certificate() (*x509.Certificate, error) {
+	return a.cert.GetRawCertificate()
+}
+
 // CertPool returns a certificate pool which is pre-populated with the
 // Certificate Authority.
 func (a *Authority) CertPool() (*x509.CertPool, error) {

--- a/config.go
+++ b/config.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 )
 
 // Config represents a half configured TLS configuration. It can be made usable
@@ -168,21 +167,41 @@ func WithClientAuthentication(authority *x509.CertPool) ServerOption {
 	}
 }
 
+// WithClientAuthenticationBuilder uses the passed PoolBuilder to create the certificate
+// pool to use as the authority when verifying client certificates.
+func WithClientAuthenticationBuilder(builder PoolBuilder) ServerOption {
+	return func(c *tls.Config) error {
+		pool, err := builder.Build()
+		if err != nil {
+			return err
+		}
+
+		return WithClientAuthentication(pool)(c)
+	}
+}
+
 // WithClientAuthenticationFromFile makes the server verify that all clients present an
 // identity that can be validated by the CA file provided.
 func WithClientAuthenticationFromFile(caPath string) ServerOption {
 	return func(c *tls.Config) error {
-		caBytes, err := ioutil.ReadFile(caPath)
+		return WithClientAuthenticationBuilder(
+			FromEmptyPool(
+				WithCertsFromFile(caPath),
+			),
+		)(c)
+	}
+}
+
+// WithAuthorityBuilder uses the passed PoolBuilder to create the certificate
+// pool to use as the authority.
+func WithAuthorityBuilder(builder PoolBuilder) ClientOption {
+	return func(c *tls.Config) error {
+		pool, err := builder.Build()
 		if err != nil {
-			return fmt.Errorf("failed to read file %s: %s", caPath, err.Error())
+			return err
 		}
 
-		caCertPool := x509.NewCertPool()
-		if ok := caCertPool.AppendCertsFromPEM(caBytes); !ok {
-			return fmt.Errorf("unable to load CA certificate at %s", caPath)
-		}
-
-		return WithClientAuthentication(caCertPool)(c)
+		return WithAuthority(pool)(c)
 	}
 }
 
@@ -199,18 +218,11 @@ func WithAuthority(authority *x509.CertPool) ClientOption {
 // that can be validated by the CA file provided.
 func WithAuthorityFromFile(caPath string) ClientOption {
 	return func(c *tls.Config) error {
-		caBytes, err := ioutil.ReadFile(caPath)
-		if err != nil {
-			return fmt.Errorf("failed to read file %s: %s", caPath, err.Error())
-		}
-
-		caCertPool := x509.NewCertPool()
-		if ok := caCertPool.AppendCertsFromPEM(caBytes); !ok {
-			return fmt.Errorf("unable to load CA certificate at %s", caPath)
-		}
-
-		c.RootCAs = caCertPool
-		return nil
+		return WithAuthorityBuilder(
+			FromEmptyPool(
+				WithCertsFromFile(caPath),
+			),
+		)(c)
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -437,7 +437,7 @@ func TestLoadCAFails(t *testing.T) {
 		{name: "CA cert file missing (server)", err: serverCAErr},
 	}
 
-	errStr := "failed to read file"
+	errStr := "failed to read certificate(s) at path"
 	for _, br := range buildResults {
 		br := br // capture variable
 		t.Run(br.name, func(t *testing.T) {
@@ -467,15 +467,27 @@ func TestCAInvalidFails(t *testing.T) {
 	}
 	defer os.Remove(invalidCAFile.Name())
 
-	_, clientCAErr := tlsconfig.Build().Client(tlsconfig.WithAuthorityFromFile(invalidCAFile.Name()))
-	_, serverCAErr := tlsconfig.Build().Server(tlsconfig.WithClientAuthenticationFromFile(invalidCAFile.Name()))
+	_, clientCAErr := tlsconfig.Build().Client(
+		tlsconfig.WithAuthorityBuilder(
+			tlsconfig.FromEmptyPool(
+				tlsconfig.WithCertsFromFile(invalidCAFile.Name()),
+			),
+		),
+	)
+	_, serverCAErr := tlsconfig.Build().Server(
+		tlsconfig.WithClientAuthenticationBuilder(
+			tlsconfig.FromEmptyPool(
+				tlsconfig.WithCertsFromFile(invalidCAFile.Name()),
+			),
+		),
+	)
 
 	buildResults := []buildResult{
 		{name: "CA cert file invalid (client)", err: clientCAErr},
 		{name: "CA cert file invalid (server)", err: serverCAErr},
 	}
 
-	errStr := "unable to load CA certificate at"
+	errStr := "no valid certificates read from file"
 	for _, br := range buildResults {
 		br := br // capture variable
 		t.Run(br.name, func(t *testing.T) {


### PR DESCRIPTION
These new helpers allow for customizing the creation of certificate
pools which can then be used when creating TLS configurations.

* Add a new Certificate() function to certest.Authority to make writing
  tests for this new functionality simpler.