### PR TITLE
enable tls 1.3 support

### DIFF
--- a/config.go
+++ b/config.go
@@ -86,7 +86,7 @@ func (c Config) Client(opts ...ClientOption) (*tls.Config, error) {
 func WithExternalServiceDefaults() TLSOption {
 	return func(c *tls.Config) error {
 		c.MinVersion = tls.VersionTLS12
-		c.MaxVersion = tls.VersionTLS12
+		c.MaxVersion = tls.VersionTLS13
 		c.PreferServerCipherSuites = false
 		c.CipherSuites = []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
@@ -95,6 +95,10 @@ func WithExternalServiceDefaults() TLSOption {
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+			tls.TLS_CHACHA20_POLY1305_SHA256,
 		}
 		return nil
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -323,8 +323,8 @@ func TestExternalDefaults(t *testing.T) {
 				t.Errorf("expected TLS 1.2 to be the minimum version; want: %v, have: %v", want, have)
 			}
 
-			if have, want := config.MaxVersion, uint16(tls.VersionTLS12); have != want {
-				t.Errorf("expected TLS 1.2 to be the maximum version; want: %v, have: %v", want, have)
+			if have, want := config.MaxVersion, uint16(tls.VersionTLS13); have != want {
+				t.Errorf("expected TLS 1.3 to be the maximum version; want: %v, have: %v", want, have)
 			}
 
 			wantSuites := []uint16{
@@ -334,6 +334,10 @@ func TestExternalDefaults(t *testing.T) {
 				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+				tls.TLS_CHACHA20_POLY1305_SHA256,
 			}
 			if have, want := config.CipherSuites, wantSuites; !reflect.DeepEqual(have, want) {
 				t.Errorf("expected a different set of ciphersuites; want: %v, have: %v", want, have)


### PR DESCRIPTION
## Please provide the following information:

### What is this change about?

Enable tls 1.3

### What problem it is trying to solve?

Not exactly a problem, but tls 1.3 is faster and in general more secure than tls 1.2

### How should this change be described in diego-release release notes?

not really if diego is not using `WithExternalServiceDefaults` function.

### Tag your pair, your PM, and/or team!

slack: `@huwang`