### PR TITLE
Bump min go version to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module code.cloudfoundry.org/tlsconfig
 
-require github.com/square/certstrap v1.2.0
+go 1.17
 
-go 1.16
+require github.com/square/certstrap v1.2.0


### PR DESCRIPTION
## Please provide the following information:

### What is this change about?

Change the minimum go version for this library to go1.17.

### What problem it is trying to solve?

go1.16 is no longer in support, so we should encourage projects
importing this library in the future to upgrade their go version to at
least 1.17.

### What is the impact if the change is not made?

Projects importing this library may continue to use go1.16.

### How should this change be described in diego-release release notes?

N/A

### Please provide any contextual information.

N/A

### Tag your pair, your PM, and/or team!

N/A