### PR TITLE
CI: update go workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
-    labels:
-      - "dependencies"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,44 +2,38 @@ name: Go
 
 on:
   push:
-    branches: [ develop ]
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  schedule:
+  - cron: '40 1 * * 2'
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Get Go version from go.mod
-      run: |
-        go_version=$(cat go.mod | grep "^go" | cut -d ' ' -f 2)
-        echo "go_version=${go_version}" >> $GITHUB_ENV
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.go_version }}
+        go-version-file: go.mod
+    - run: go test -v -race ./...
 
-    - name: Build
-      run: go build -v ./...
-
-    - name: Test
-      run: go test -v ./...
-
-  promote:
-    needs: test
+  vet:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        # fetch-depth: Number of commits to fetch. 0 indicates all history for all branches and tags.
-        fetch-depth: 0
-    - name: Promote to master
-      run: |
-        git fetch --all
+        go-version-file: go.mod
+    - run: go vet ./...
 
-        git checkout master
-        git pull --rebase
-
-        git rebase develop
-        git push
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
+    - uses: golangci/golangci-lint-action@v3.3.0

--- a/authority.go
+++ b/authority.go
@@ -4,7 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // PoolOption is an functional option type that can be used to configure a
@@ -59,7 +59,7 @@ func FromSystemPool(opts ...PoolOption) PoolBuilder {
 // file to a certificate pool.
 func WithCertsFromFile(path string) PoolOption {
 	return func(pool *x509.CertPool) error {
-		pemCerts, err := ioutil.ReadFile(path)
+		pemCerts, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("failed to read certificate(s) at path %q: %s", path, err)
 		}

--- a/authority_test.go
+++ b/authority_test.go
@@ -1,7 +1,6 @@
 package tlsconfig
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -90,7 +89,7 @@ func TestLoadCertsFromFile(t *testing.T) {
 		t.Fatalf("failed to PEM-encode certificate: %s", err)
 	}
 
-	f, err := ioutil.TempFile("", "tlsconfig_authority")
+	f, err := os.CreateTemp("", "tlsconfig_authority")
 	if err != nil {
 		t.Fatalf("failed to create temporary certificate file: %s", err)
 	}

--- a/authority_test.go
+++ b/authority_test.go
@@ -1,6 +1,7 @@
 package tlsconfig
 
 import (
+	"crypto/x509"
 	"os"
 	"strings"
 	"testing"
@@ -15,8 +16,8 @@ func TestEmptyPool(t *testing.T) {
 		t.Fatalf("unexpected error when building empty pool: %q", err)
 	}
 
-	if size := len(pool.Subjects()); size != 0 {
-		t.Errorf("expected pool to be empty but it had %d certificates", size)
+	if !pool.Equal(x509.NewCertPool()) {
+		t.Errorf("expected pool to be empty")
 	}
 }
 
@@ -27,8 +28,12 @@ func TestSystemPool(t *testing.T) {
 		t.Fatalf("unexpected error when building system pool: %q", err)
 	}
 
-	if size := len(pool.Subjects()); size == 0 {
-		t.Error("expected pool to contain something but it did not")
+	systemPool, err := x509.SystemCertPool()
+	if err != nil {
+		t.Fatalf("unexpected error when getting system pool: %q", err)
+	}
+	if !pool.Equal(systemPool) {
+		t.Errorf("expected pool to equal %#v, got %#v", systemPool, pool)
 	}
 }
 
@@ -52,11 +57,11 @@ func TestWithCert(t *testing.T) {
 		t.Fatalf("unexpected error when building pool: %q", err)
 	}
 
-	if want, have := 1, len(pool.Subjects()); have != want {
+	if want, have := 1, len(pool.Subjects()); have != want { //nolint:staticcheck
 		t.Errorf("expected pool to have size %d but it had %d certificates", want, have)
 	}
 
-	if s, subj := "theauthority", string(pool.Subjects()[0]); !strings.Contains(subj, s) {
+	if s, subj := "theauthority", string(pool.Subjects()[0]); !strings.Contains(subj, s) { //nolint:staticcheck
 		t.Errorf("pool should have contained cert with subject %q but it was acutally %q", s, subj)
 	}
 }
@@ -115,15 +120,15 @@ func TestLoadCertsFromFile(t *testing.T) {
 	}
 
 	// We add 2 certificates to the pool from the file.
-	if want, have := 2, len(pool.Subjects()); have != want {
+	if want, have := 2, len(pool.Subjects()); have != want { //nolint:staticcheck
 		t.Errorf("expected pool to have size %d but it had %d certificates", want, have)
 	}
 
-	if s, subj := "cert1", string(pool.Subjects()[0]); !strings.Contains(subj, s) {
+	if s, subj := "cert1", string(pool.Subjects()[0]); !strings.Contains(subj, s) { //nolint:staticcheck
 		t.Errorf("pool should have contained cert with subject %q but it was acutally %q", s, subj)
 	}
 
-	if s, subj := "cert2", string(pool.Subjects()[1]); !strings.Contains(subj, s) {
+	if s, subj := "cert2", string(pool.Subjects()[1]); !strings.Contains(subj, s) { //nolint:staticcheck
 		t.Errorf("pool should have contained cert with subject %q but it was acutally %q", s, subj)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -139,7 +139,7 @@ func WithIdentity(cert tls.Certificate) TLSOption {
 			return fail(err)
 		}
 		c.Certificates = []tls.Certificate{cert}
-		c.BuildNameToCertificate()
+		c.BuildNameToCertificate() //nolint:staticcheck
 		return nil
 	}
 }

--- a/config.go
+++ b/config.go
@@ -87,7 +87,6 @@ func WithExternalServiceDefaults() TLSOption {
 	return func(c *tls.Config) error {
 		c.MinVersion = tls.VersionTLS12
 		c.MaxVersion = tls.VersionTLS13
-		c.PreferServerCipherSuites = false
 		c.CipherSuites = []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
@@ -116,7 +115,6 @@ func WithInternalServiceDefaults() TLSOption {
 	return func(c *tls.Config) error {
 		c.MinVersion = tls.VersionTLS12
 		c.MaxVersion = tls.VersionTLS13
-		c.PreferServerCipherSuites = true
 		c.CipherSuites = []uint16{
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,

--- a/config_test.go
+++ b/config_test.go
@@ -67,7 +67,7 @@ func TestE2E(t *testing.T) {
 		t.Fatalf("failed to build server config: %v", err)
 	}
 
-	if serverConf.NameToCertificate == nil {
+	if serverConf.NameToCertificate == nil { //nolint:staticcheck
 		t.Error("tls.Config.NameToCertificate should not be nil")
 	}
 
@@ -80,7 +80,7 @@ func TestE2E(t *testing.T) {
 		t.Fatalf("failed to build client config: %v", err)
 	}
 
-	if clientConf.NameToCertificate == nil {
+	if clientConf.NameToCertificate == nil { //nolint:staticcheck
 		t.Error("tls.Config.NameToCertificate should not be nil")
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -253,10 +253,6 @@ func TestInternalDefaults(t *testing.T) {
 			t.Parallel()
 			config := tc.config
 
-			if have, want := config.PreferServerCipherSuites, true; have != want {
-				t.Errorf("expected server cipher suites to be preferred; have: %t", have)
-			}
-
 			if have, want := config.MinVersion, uint16(tls.VersionTLS12); have != want {
 				t.Errorf("expected TLS 1.2 to be the minimum version; want: %v, have: %v", want, have)
 			}
@@ -314,10 +310,6 @@ func TestExternalDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			config := tc.config
-
-			if have, want := config.PreferServerCipherSuites, false; have != want {
-				t.Errorf("expected server cipher suites not to be preferred; have: %t", have)
-			}
 
 			if have, want := config.MinVersion, uint16(tls.VersionTLS12); have != want {
 				t.Errorf("expected TLS 1.2 to be the minimum version; want: %v, have: %v", want, have)

--- a/config_test.go
+++ b/config_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -88,7 +88,7 @@ func TestE2E(t *testing.T) {
 }
 
 func TestE2EFromFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temp directory: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestServerName(t *testing.T) {
 }
 
 func TestInternalDefaults(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	t.Parallel()
 
 	clientConfig, err := tlsconfig.Build(tlsconfig.WithInternalServiceDefaults()).Client()
@@ -283,7 +283,7 @@ func TestInternalDefaults(t *testing.T) {
 }
 
 func TestExternalDefaults(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	t.Parallel()
 
 	clientConfig, err := tlsconfig.Build(tlsconfig.WithExternalServiceDefaults()).Client()
@@ -351,7 +351,7 @@ func TestExternalDefaults(t *testing.T) {
 func TestLoadKeypairFails(t *testing.T) {
 	t.Parallel()
 
-	tempDir, err := ioutil.TempDir("", "")
+	tempDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temp directory: %v", err)
 	}
@@ -368,13 +368,13 @@ func TestLoadKeypairFails(t *testing.T) {
 	}
 
 	// generate file invalid for use as cert or key
-	invalidFile, err := ioutil.TempFile(tempDir, "invalid")
+	invalidFile, err := os.CreateTemp(tempDir, "invalid")
 	if err != nil {
 		t.Fatalf("failed to create temp invalid-key: %v", err)
 	}
 	defer invalidFile.Close()
 
-	if err := ioutil.WriteFile(invalidFile.Name(), []byte("invalid"), 0666); err != nil {
+	if err := os.WriteFile(invalidFile.Name(), []byte("invalid"), 0666); err != nil {
 		t.Fatalf("failed to write invalid file: %v", err)
 	}
 
@@ -464,13 +464,13 @@ func TestLoadCAFails(t *testing.T) {
 func TestCAInvalidFails(t *testing.T) {
 	t.Parallel()
 
-	invalidCAFile, err := ioutil.TempFile("", "invalid-CA")
+	invalidCAFile, err := os.CreateTemp("", "invalid-CA")
 	if err != nil {
 		t.Fatalf("failed to create temp invalid-CA: %v", err)
 	}
 	defer invalidCAFile.Close()
 
-	if err := ioutil.WriteFile(invalidCAFile.Name(), []byte("invalid"), 0666); err != nil {
+	if err := os.WriteFile(invalidCAFile.Name(), []byte("invalid"), 0666); err != nil {
 		t.Fatalf("failed to write invalid-CA file: %v", err)
 	}
 	defer os.Remove(invalidCAFile.Name())
@@ -526,7 +526,7 @@ func testClientServerTLSConnection(t *testing.T, clientConf, serverConf *tls.Con
 	if err != nil {
 		t.Fatalf("failed to make request: %v", err)
 	}
-	bs, err := ioutil.ReadAll(res.Body)
+	bs, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("failed to read body: %v", err)
 	}
@@ -543,13 +543,13 @@ func writeCAToTempFile(tempDir string, ca *certtest.Authority) (string, error) {
 		return "", fmt.Errorf("failed to get CA PEM encoding: %s", err)
 	}
 
-	caFile, err := ioutil.TempFile(tempDir, "CA")
+	caFile, err := os.CreateTemp(tempDir, "CA")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp CA file: %s", err)
 	}
 	defer caFile.Close()
 
-	if err := ioutil.WriteFile(caFile.Name(), caBytes, 0666); err != nil {
+	if err := os.WriteFile(caFile.Name(), caBytes, 0666); err != nil {
 		return "", fmt.Errorf("failed to write CA file: %s", err)
 	}
 
@@ -575,23 +575,23 @@ func generateKeypairToTempFilesFromCA(tempDir string, ca *certtest.Authority, ex
 		return "", "", fmt.Errorf("failed to get cert and key bytes: %s", err)
 	}
 
-	keyFile, err := ioutil.TempFile(tempDir, "key")
+	keyFile, err := os.CreateTemp(tempDir, "key")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create temp key file: %s", err)
 	}
 	defer keyFile.Close()
 
-	if err := ioutil.WriteFile(keyFile.Name(), keyBytes, 0666); err != nil {
+	if err := os.WriteFile(keyFile.Name(), keyBytes, 0666); err != nil {
 		return "", "", fmt.Errorf("failed to write key file: %s", err)
 	}
 
-	certFile, err := ioutil.TempFile(tempDir, "cert")
+	certFile, err := os.CreateTemp(tempDir, "cert")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create temp cert file: %s", err)
 	}
 	defer certFile.Close()
 
-	if err := ioutil.WriteFile(certFile.Name(), certBytes, 0666); err != nil {
+	if err := os.WriteFile(certFile.Name(), certBytes, 0666); err != nil {
 		return "", "", fmt.Errorf("failed to write cert file: %s", err)
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -554,7 +554,7 @@ func generateKeypairToTempFilesFromCA(tempDir string, ca *certtest.Authority, ex
 		err  error
 	)
 	if expired {
-		cert, err = ca.BuildSignedCertificateWithExpiry("cert", time.Now().Add(-10000))
+		cert, err = ca.BuildSignedCertificate("cert", certtest.WithExpiry(time.Now().Add(-10000)))
 	} else {
 		cert, err = ca.BuildSignedCertificate("cert")
 	}


### PR DESCRIPTION
This only changes the GH actions go workflow.

Run the workflow on master instead of develop, as we don't want to follow the develop/master promotion cycle anymore.

Also:
* Run `go vet` and linting via `golangci-lint`.
* Run on a cron schedule, not just on push and PRs.