### PR TITLE
Remove deprecated call

### DIFF
--- a/config.go
+++ b/config.go
@@ -139,7 +139,6 @@ func WithIdentity(cert tls.Certificate) TLSOption {
 			return fail(err)
 		}
 		c.Certificates = []tls.Certificate{cert}
-		c.BuildNameToCertificate() //nolint:staticcheck
 		return nil
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -78,6 +78,7 @@ func TestE2E(t *testing.T) {
 
 	testClientServerTLSConnection(t, clientConf, serverConf)
 
+	// found certificate in list, and negotiated TLS successfully
 	if clientConf.InsecureSkipVerify != false {
 	   t.Error("failed, expected certificate validation to be enabled")
 	}
@@ -136,6 +137,7 @@ func TestE2EFromFile(t *testing.T) {
 
 	testClientServerTLSConnection(t, clientConf, serverConf)
 
+	// found certificate in list, and negotiated TLS successfully
 	if clientConf.InsecureSkipVerify != false {
 	   t.Error("failed, expected certificate validation to be enabled")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -79,7 +79,7 @@ func TestE2E(t *testing.T) {
 	testClientServerTLSConnection(t, clientConf, serverConf)
 
 	if clientConf.InsecureSkipVerify != false {
-	   t.Error("failed, expected certificate validation")
+	   t.Error("failed, expected certificate validation to be enabled")
 	}
 	if len(clientConf.Certificates) == 0 {
 	   t.Error("failed, expected client to negotiate certificate")
@@ -137,7 +137,7 @@ func TestE2EFromFile(t *testing.T) {
 	testClientServerTLSConnection(t, clientConf, serverConf)
 
 	if clientConf.InsecureSkipVerify != false {
-	   t.Error("failed, expected certificate validation")
+	   t.Error("failed, expected certificate validation to be enabled")
 	}
 	if len(clientConf.Certificates) == 0 {
 	   t.Error("failed, expected client to negotiate certificate")

--- a/config_test.go
+++ b/config_test.go
@@ -67,10 +67,6 @@ func TestE2E(t *testing.T) {
 		t.Fatalf("failed to build server config: %v", err)
 	}
 
-	if serverConf.NameToCertificate == nil { //nolint:staticcheck
-		t.Error("tls.Config.NameToCertificate should not be nil")
-	}
-
 	clientConf, err := tlsconfig.Build(
 		tlsconfig.WithIdentity(clientTLSCrt),
 	).Client(
@@ -80,11 +76,14 @@ func TestE2E(t *testing.T) {
 		t.Fatalf("failed to build client config: %v", err)
 	}
 
-	if clientConf.NameToCertificate == nil { //nolint:staticcheck
-		t.Error("tls.Config.NameToCertificate should not be nil")
-	}
-
 	testClientServerTLSConnection(t, clientConf, serverConf)
+
+	if clientConf.InsecureSkipVerify != false {
+	   t.Error("failed, expected certificate validation")
+	}
+	if len(clientConf.Certificates) == 0 {
+	   t.Error("failed, expected client to negotiate certificate")
+	}
 }
 
 func TestE2EFromFile(t *testing.T) {
@@ -136,6 +135,13 @@ func TestE2EFromFile(t *testing.T) {
 	}
 
 	testClientServerTLSConnection(t, clientConf, serverConf)
+
+	if clientConf.InsecureSkipVerify != false {
+	   t.Error("failed, expected certificate validation")
+	}
+	if len(clientConf.Certificates) == 0 {
+	   t.Error("failed, expected client to negotiate certificate")
+	}
 }
 
 func TestServerName(t *testing.T) {


### PR DESCRIPTION
 ***************************

## Please provide the following information:

### What is this change about?

> [Remove BuildNameToCertificate](https://github.com/cloudfoundry/tlsconfig/issues/28) asks the titular question of removing a call deprecated in golang 

### What problem it is trying to solve?

> A deprecated call in crypto/tls is being used in the tlsconfig library, behavior has changed such that it is no longer needed.

### What is the impact if the change is not made?

> The crypt/tls library is sending a signal that this call will be dropped. When it is dropped, tlsconfig will break.

### How should this change be described in diego-release release notes?

> Deprecated routine BuildNameToCertificate dropped from use.

### Please provide any contextual information.

> [Issue 28](https://github.com/cloudfoundry/tlsconfig/issues/28) highlights the deprecation of the call, but stops short of removing it.  This update (a) removes the call which is replaced by suitable default behavior, (b) adds some tests to validate appropriate results from default behavior.  The InsecureSkipVerify test is possibly not needed.

### Tag your pair, your PM, and/or team!

> 

Thank you!
