### PR TITLE
docs: remove retired go report card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # tlsconfig
 
-[![Go Report
-Card](https://goreportcard.com/badge/code.cloudfoundry.org/tlsconfig)](https://goreportcard.com/report/code.cloudfoundry.org/tlsconfig)
 [![Go
 Reference](https://pkg.go.dev/badge/code.cloudfoundry.org/tlsconfig.svg)](https://pkg.go.dev/code.cloudfoundry.org/tlsconfig)
 


### PR DESCRIPTION
Summary:
- remove the retired Go Report Card badge/link from the README
- keep the Go Reference badge in place

Validation:
- `git diff --check`
- `curl.exe -I -L https://pkg.go.dev/badge/code.cloudfoundry.org/tlsconfig.svg`

Closes #48